### PR TITLE
feat: add ability to serve files as if they were in production

### DIFF
--- a/lib/one.js
+++ b/lib/one.js
@@ -341,7 +341,13 @@ exports.init = function (gulp, options) {
         },
 
         writeToProd: stream => stream
-            .pipe(gulp.dest(one.options.prod))
+            .pipe(gulp.dest(one.options.prod)),
+
+        browserSyncProd: stream => {
+            return stream
+                .pipe($.cached('sync'))
+                .pipe(servers.reloadBrowserSync());
+        }
 
     };
     one.load(one.outputs);
@@ -408,6 +414,7 @@ exports.init = function (gulp, options) {
 
     one.link(one.sources.images).to(one.transforms.imagemin);
     one.link(one.transforms.imagemin).to(one.outputs.writeToProd);
+    one.link(one.outputs.writeToProd).to(one.outputs.browserSyncProd);
 
     // TASKS
 
@@ -415,8 +422,17 @@ exports.init = function (gulp, options) {
         return one.run(one.outputs.browserSync);
     });
 
+    gulp.task('browserSyncProd', function () {
+        return one.run(one.outputs.browserSyncProd);
+    });
+
     gulp.task('serve', ['browserSync'], function () {
         servers.startStatic(one.options);
+        servers.startBrowserSync(one.options);
+    });
+
+    gulp.task('serve-prod', ['browserSyncProd'], function () {
+        servers.startStaticProd(one.options);
         servers.startBrowserSync(one.options);
     });
 

--- a/lib/servers.js
+++ b/lib/servers.js
@@ -25,6 +25,15 @@ module.exports = {
         loggers.server('static', options.bindHost, options.connectPort);
     },
 
+    startStaticProd(options) {
+
+        var app = connect();
+        app.use(serveStatic(options.prod));
+        app.listen(options.connectPort, options.bindHost);
+
+        loggers.server('static', options.bindHost, options.connectPort);
+    },
+
     startBrowserSync(options) {
 
         var browserSyncOptions = {


### PR DESCRIPTION
I faced the need :)
I was able to reproduce a bug only on integration environments, not on my machine. Turns out the bug was created during the minifying process.
I figured it would be nice to have a "gulp serve-prod" thing, that would serve files as if they were deployed in production.